### PR TITLE
Added CosmosClientOptions to UseCosmosDbPersistence method and CosmosClientFactory constructor

### DIFF
--- a/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Providers.Azure.Interface;
@@ -31,14 +32,15 @@ namespace Microsoft.Extensions.DependencyInjection
             this WorkflowOptions options,
             string connectionString,
             string databaseId,
-            CosmosDbStorageOptions cosmosDbStorageOptions = null)
+            CosmosDbStorageOptions cosmosDbStorageOptions = null,
+            CosmosClientOptions clientOptions = null)
         {
             if (cosmosDbStorageOptions == null)
             {
                 cosmosDbStorageOptions = new CosmosDbStorageOptions();
             }
 
-            options.Services.AddSingleton<ICosmosClientFactory>(sp => new CosmosClientFactory(connectionString));
+            options.Services.AddSingleton<ICosmosClientFactory>(sp => new CosmosClientFactory(connectionString, clientOptions));
             options.Services.AddTransient<ICosmosDbProvisioner>(sp => new CosmosDbProvisioner(sp.GetService<ICosmosClientFactory>(), cosmosDbStorageOptions));
             options.Services.AddSingleton<IWorkflowPurger>(sp => new WorkflowPurger(sp.GetService<ICosmosClientFactory>(), databaseId, cosmosDbStorageOptions));
             options.UsePersistence(sp => new CosmosDbPersistenceProvider(sp.GetService<ICosmosClientFactory>(), databaseId, sp.GetService<ICosmosDbProvisioner>(), cosmosDbStorageOptions));

--- a/src/providers/WorkflowCore.Providers.Azure/Services/CosmosClientFactory.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/Services/CosmosClientFactory.cs
@@ -10,9 +10,9 @@ namespace WorkflowCore.Providers.Azure.Services
 
         private CosmosClient _client;
 
-        public CosmosClientFactory(string connectionString)
+        public CosmosClientFactory(string connectionString, CosmosClientOptions clientOptions = null)
         {
-            _client = new CosmosClient(connectionString);
+            _client = new CosmosClient(connectionString, clientOptions);
         }
 
         public CosmosClient GetCosmosClient()


### PR DESCRIPTION

**Describe the change**
Added CosmosClientOptions to UseCosmosDbPersistence method and CosmosClientFactory constructor to pass additional configuration
over to the CosmosClient.

**Describe your implementation or design**
Added CosmosClientOptions to UseCosmosDbPersistence method and CosmosClientFactory constructor with a default value of "null"
so as not to break existing codebases.

**Tests**
N/A

**Breaking change**
No.

**Additional context**
By default, CosmosClient uses the "Direct" ConnectionMethod. This does not always work. To fix this, I wanted to pass the "ConnectionMethod"
option. But looking at other providers "ElasticSearch", I saw that the configuration object for ElasticClient was passed to the DI methods. So, I
used a similar approach here.